### PR TITLE
Set the default vscode latex workshop to use latexmkrc

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "latex-workshop.latex.recipe.default": "latexmk (latexmkrc)"
+}


### PR DESCRIPTION
The repository only compiles with latexmk if the latexmkrc configuration file is used therefore the vscode recipe to use should be the one that uses the latexmkrc file.