### PR TITLE
fix: set minted outputdir to .aux and minor .latexmkrc adjustment

### DIFF
--- a/.latexmkrc
+++ b/.latexmkrc
@@ -17,7 +17,7 @@
 $pdf_mode = 5;
 
 # Main TeX file.
-$root_filename = 'IPleiriaMain.tex';
+$root_filename = 'IPLeiriaMain.tex';
 
 # Additional flags for the TeX engine.
 set_tex_cmds("--shell-escape --synctex=1 --file-line-error --halt-on-error %O %S");

--- a/IPLeiriaThesis.cls
+++ b/IPLeiriaThesis.cls
@@ -163,7 +163,7 @@
 \RequirePackage{typearea} % Page layout adjustments (KOMA-Script).
 \RequirePackage{eso-pic} % Adding elements to the page background.
 \RequirePackage{setspace} % Adjust line spacing.
-\RequirePackage[newfloat]{minted} % Syntax highlighting for code.
+\RequirePackage[newfloat,outputdir=.aux]{minted} % Syntax highlighting for code.
 \RequirePackage{silence} % Suppress specific package warnings.
 \RequirePackage{fontawesome5} % Font awesome icons.
 \RequirePackage{calc} % Infix notation arithmetic.


### PR DESCRIPTION
Building the document on Linux using the provided `Makefile` failed with minted’s "Missing Pygments output" error. Minted wrote its temporary Pygments files to the root directory, while LaTeX expected them inside `.aux`.

Fixed this by setting `outputdir=.aux` for minted, so all Pygments output goes to `.aux/_minted-*`.
As an extra, updated the main filename in `.latexmkrc` to match the actual file name for consistency, even though it builds fine either way.